### PR TITLE
Added missing battery SoC and icon for it

### DIFF
--- a/custom_components/solakon_one/const.py
+++ b/custom_components/solakon_one/const.py
@@ -66,6 +66,7 @@ REGISTERS = {
     "battery1_current": {"address": 39228, "count": 2, "type": "i32", "scale": 1000, "unit": "A"},
     "battery1_power": {"address": 39230, "count": 2, "type": "i32", "scale": 1, "unit": "W"},
     "battery_combined_power": {"address": 39237, "count": 2, "type": "i32", "scale": 1, "unit": "W"},
+    "battery_soc": {"address": 39424, "count": 1, "type": "i16", "scale": 1, "unit": "%"},
 }
 
 # Sensor definitions for Home Assistant
@@ -98,6 +99,13 @@ SENSOR_DEFINITIONS = {
         "state_class": "measurement",
         "unit": "W",
         "icon": "mdi:battery-charging",
+    },
+    "battery_soc": {
+        "name": "Battery State of Charge",
+        "device_class": "battery",
+        "state_class": "measurement",
+        "unit": "%",
+        "icon": "mdi:battery",
     },
     
     # Voltage sensors

--- a/custom_components/solakon_one/manifest.json
+++ b/custom_components/solakon_one/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/solakon-de/solakon-one-homeassistant/issues",
-  "requirements": ["pymodbus==3.11.1"],
+  "requirements": ["pymodbus>=3.11.1"],
   "version": "1.0.0"
 }

--- a/custom_components/solakon_one/sensor.py
+++ b/custom_components/solakon_one/sensor.py
@@ -175,6 +175,28 @@ class SolakonSensor(CoordinatorEntity, SensorEntity):
         self.async_write_ha_state()
 
     @property
+    def icon(self) -> str | None:
+        """Return the icon to use in the frontend."""
+        # battery soc sensor
+        if self._sensor_key == "battery_soc":
+            try:
+                soc = int(self.native_value)
+            except (ValueError, TypeError):
+                return "mdi:battery-unknown"
+
+            if soc > 90:
+                return "mdi:battery"
+            
+            rounded_soc = (soc + 5) // 10 * 10
+            if rounded_soc == 0:
+                return "mdi:battery-outline"
+            
+            return f"mdi:battery-{rounded_soc}"
+        
+        # For all other sensors return the static icon defined in const.py
+        return self._definition.get("icon")
+
+    @property
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success and self._attr_native_value is not None


### PR DESCRIPTION
Since I was missing the battery SoC I searched for the address in the modbus and simply added it.
This works fine for me now since 2 weeks.
Until it's officially released I will wait with the update of the repository in my HA.