### PR TITLE
bugfixes und modbus-update limit runtergesetzt

### DIFF
--- a/custom_components/solakon_one/config_flow.py
+++ b/custom_components/solakon_one/config_flow.py
@@ -27,7 +27,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
             vol.Coerce(int), vol.Range(min=1, max=247)
         ),
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
-            vol.Coerce(int), vol.Range(min=10, max=300)
+            vol.Coerce(int), vol.Range(min=1, max=300)
         ),
     }
 )

--- a/custom_components/solakon_one/const.py
+++ b/custom_components/solakon_one/const.py
@@ -40,7 +40,7 @@ REGISTERS = {
     "pv3_current": {"address": 39075, "count": 1, "type": "i16", "scale": 100, "unit": "A"},
     "pv4_voltage": {"address": 39076, "count": 1, "type": "i16", "scale": 10, "unit": "V"},
     "pv4_current": {"address": 39077, "count": 1, "type": "i16", "scale": 100, "unit": "A"},
-    "total_pv_power": {"address": 39118, "count": 2, "type": "i32", "scale": 1000, "unit": "kW"},
+    "total_pv_power": {"address": 39118, "count": 2, "type": "i32", "scale": 1000, "unit": "W"},
     
     # Grid Information
     "grid_r_voltage": {"address": 39123, "count": 1, "type": "i16", "scale": 10, "unit": "V"},
@@ -49,7 +49,7 @@ REGISTERS = {
     "inverter_r_current": {"address": 39126, "count": 2, "type": "i32", "scale": 1000, "unit": "A"},
     "inverter_s_current": {"address": 39128, "count": 2, "type": "i32", "scale": 1000, "unit": "A"},
     "inverter_t_current": {"address": 39130, "count": 2, "type": "i32", "scale": 1000, "unit": "A"},
-    "active_power": {"address": 39134, "count": 2, "type": "i32", "scale": 1000, "unit": "kW"},
+    "active_power": {"address": 39134, "count": 2, "type": "i32", "scale": 1000, "unit": "W"},
     "reactive_power": {"address": 39136, "count": 2, "type": "i32", "scale": 1000, "unit": "kvar"},
     "power_factor": {"address": 39138, "count": 1, "type": "i16", "scale": 1000},
     "grid_frequency": {"address": 39139, "count": 1, "type": "i16", "scale": 100, "unit": "Hz"},
@@ -94,14 +94,14 @@ SENSOR_DEFINITIONS = {
         "name": "PV Power",
         "device_class": "power",
         "state_class": "measurement",
-        "unit": "kW",
+        "unit": "W",
         "icon": "mdi:solar-power",
     },
     "active_power": {
         "name": "Active Power",
         "device_class": "power",
         "state_class": "measurement",
-        "unit": "kW",
+        "unit": "W",
         "icon": "mdi:flash",
     },
     "reactive_power": {

--- a/custom_components/solakon_one/const.py
+++ b/custom_components/solakon_one/const.py
@@ -40,7 +40,7 @@ REGISTERS = {
     "pv3_current": {"address": 39075, "count": 1, "type": "i16", "scale": 100, "unit": "A"},
     "pv4_voltage": {"address": 39076, "count": 1, "type": "i16", "scale": 10, "unit": "V"},
     "pv4_current": {"address": 39077, "count": 1, "type": "i16", "scale": 100, "unit": "A"},
-    "total_pv_power": {"address": 39118, "count": 2, "type": "i32", "scale": 1000000, "unit": "W"},
+    "total_pv_power": {"address": 39118, "count": 2, "type": "i32", "scale": 1, "unit": "W"},
     
     # Grid Information
     "grid_r_voltage": {"address": 39123, "count": 1, "type": "i16", "scale": 10, "unit": "V"},
@@ -49,7 +49,7 @@ REGISTERS = {
     "inverter_r_current": {"address": 39126, "count": 2, "type": "i32", "scale": 1000, "unit": "A"},
     "inverter_s_current": {"address": 39128, "count": 2, "type": "i32", "scale": 1000, "unit": "A"},
     "inverter_t_current": {"address": 39130, "count": 2, "type": "i32", "scale": 1000, "unit": "A"},
-    "active_power": {"address": 39134, "count": 2, "type": "i32", "scale": 1000000, "unit": "W"},
+    "active_power": {"address": 39134, "count": 2, "type": "i32", "scale": 1, "unit": "W"},
     "reactive_power": {"address": 39136, "count": 2, "type": "i32", "scale": 1000, "unit": "kvar"},
     "power_factor": {"address": 39138, "count": 1, "type": "i16", "scale": 1000},
     "grid_frequency": {"address": 39139, "count": 1, "type": "i16", "scale": 100, "unit": "Hz"},

--- a/custom_components/solakon_one/const.py
+++ b/custom_components/solakon_one/const.py
@@ -40,7 +40,7 @@ REGISTERS = {
     "pv3_current": {"address": 39075, "count": 1, "type": "i16", "scale": 100, "unit": "A"},
     "pv4_voltage": {"address": 39076, "count": 1, "type": "i16", "scale": 10, "unit": "V"},
     "pv4_current": {"address": 39077, "count": 1, "type": "i16", "scale": 100, "unit": "A"},
-    "total_pv_power": {"address": 39118, "count": 2, "type": "i32", "scale": 1000, "unit": "W"},
+    "total_pv_power": {"address": 39118, "count": 2, "type": "i32", "scale": 1000000, "unit": "W"},
     
     # Grid Information
     "grid_r_voltage": {"address": 39123, "count": 1, "type": "i16", "scale": 10, "unit": "V"},
@@ -49,7 +49,7 @@ REGISTERS = {
     "inverter_r_current": {"address": 39126, "count": 2, "type": "i32", "scale": 1000, "unit": "A"},
     "inverter_s_current": {"address": 39128, "count": 2, "type": "i32", "scale": 1000, "unit": "A"},
     "inverter_t_current": {"address": 39130, "count": 2, "type": "i32", "scale": 1000, "unit": "A"},
-    "active_power": {"address": 39134, "count": 2, "type": "i32", "scale": 1000, "unit": "W"},
+    "active_power": {"address": 39134, "count": 2, "type": "i32", "scale": 1000000, "unit": "W"},
     "reactive_power": {"address": 39136, "count": 2, "type": "i32", "scale": 1000, "unit": "kvar"},
     "power_factor": {"address": 39138, "count": 1, "type": "i16", "scale": 1000},
     "grid_frequency": {"address": 39139, "count": 1, "type": "i16", "scale": 100, "unit": "Hz"},

--- a/custom_components/solakon_one/translations/en.json
+++ b/custom_components/solakon_one/translations/en.json
@@ -16,7 +16,7 @@
           "port": "Modbus TCP port (usually 502)",
           "name": "Friendly name for your device",
           "slave_id": "Modbus slave address (1-247)",
-          "scan_interval": "How often to poll the device (10-300 seconds)"
+          "scan_interval": "How often to poll the device (1-300 seconds)"
         }
       }
     },


### PR DESCRIPTION
sowohl PV-power als auch active power wurden in kW angegeben, was unsinnig ist und ne potenzielle Fehlerquelle...
-> beide auf W geändert

modbus ist ein request, die sensor werte aber push notifications, ein request jede sekunde erhöht die last im netzwerk sonst nichts
->es sei denn ich verstehe etwas grundlegend falsch<-

für eine funktionierende Nulleinspeisung über z.B. einen Homeassistant Automationen sind sekündliche Werte deutlich besser als 10 sekündliche Werte ;)
