### PR TITLE
fix: device class for Max Charge/Max Discharge

### DIFF
--- a/custom_components/solakon_one/const.py
+++ b/custom_components/solakon_one/const.py
@@ -335,14 +335,14 @@ SENSOR_DEFINITIONS = {
     },
     "battery_max_charge_current": {
     "name": "Maximum Charge Current",
-        "device_class": "battery",
+        "device_class": "current",
         "state_class": "number",
         "unit": "A",
         "icon": "mdi:battery-charging",
     },
     "battery_max_discharge_current":{
     "name": "Maximum Discharge Current",
-        "device_class": "battery",
+        "device_class": "current",
         "state_class": "number",
         "unit": "A",
         "icon": "mdi:battery-charging",


### PR DESCRIPTION
Fixed wrong device_class 
-maximum_charge_current
-maximum_discharge_current

Closes #25 