### PR TITLE
fix: adapt deprecated patterns

### DIFF
--- a/custom_components/solakon_one/__init__.py
+++ b/custom_components/solakon_one/__init__.py
@@ -35,7 +35,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady("Cannot connect to Solakon ONE device")
 
     coordinator = SolakonDataCoordinator(hass, hub)
-    await coordinator.async_config_entry_first_refresh()
+    # Coordinator isn't tied to a config entry object, so call a regular refresh
+    # rather than async_config_entry_first_refresh which is only supported
+    # for coordinators that are created with a config entry.
+    await coordinator.async_refresh()
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {

--- a/custom_components/solakon_one/config_flow.py
+++ b/custom_components/solakon_one/config_flow.py
@@ -102,7 +102,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        # Do not set `self.config_entry` on the flow handler (deprecated).
+        # Store as a private attribute instead.
+        self._config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -117,7 +119,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
-                        default=self.config_entry.data.get(
+                        default=self._config_entry.data.get(
                             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
                         ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=1, max=300)),


### PR DESCRIPTION
custom integration 'solakon_one' sets option flow config_entry explicitly, which is deprecated at
custom_components/solakon_one/config_flow.py, line 105: self.config_entry = config_entry.
This will stop working in Home Assistant 2025.12

custom integration 'solakon_one' uses
`async_config_entry_first_refresh`, which is only supported for coordinators with a config entry at
custom_components/solakon_one/__init__.py, line 38: await coordinator.async_config_entry_first_refresh(). This will stop working in Home Assistant 2025.11

Should fix: #31 #30

Tested with:
https://github.com/mkunzmann/solakon-one-homeassistant-2/commit/61a0ae03e2c6d727a35ab047743c4abc3072de03
Which adds a devcontainers environment and a modbus simulator to have a simple test device.