### PR TITLE
refactor!: remove duplicate sensors

### DIFF
--- a/custom_components/solakon_one/const.py
+++ b/custom_components/solakon_one/const.py
@@ -314,9 +314,6 @@ SENSOR_DEFINITIONS = {
     },
 
     # Control Status Sensors (showing current values of controllable parameters)
-    "eps_output": {
-        "name": "EPS Output Mode",
-    },
     # "export_power_limit": {
     #     "name": "Export Power Limit",
     #     "device_class": "power",

--- a/custom_components/solakon_one/const.py
+++ b/custom_components/solakon_one/const.py
@@ -338,36 +338,6 @@ SENSOR_DEFINITIONS = {
     #     "unit": "W",
     #     "icon": "mdi:transmission-tower-export",
     # },
-    "minimum_soc": {
-        "name": "Minimum State of Charge",
-        "device_class": "battery",
-        "state_class": "measurement",
-        "unit": "%",
-    },
-    "maximum_soc": {
-        "name": "Maximum State of Charge",
-        "device_class": "battery",
-        "state_class": "measurement",
-        "unit": "%",
-    },
-    "minimum_soc_ongrid": {
-        "name": "Minimum SoC OnGrid",
-        "device_class": "battery",
-        "state_class": "measurement",
-        "unit": "%",
-    },
-    "battery_max_charge_current": {
-        "name": "Maximum Charge Current",
-        "device_class": "current",
-        "state_class": "number",
-        "unit": "A",
-    },
-    "battery_max_discharge_current":{
-        "name": "Maximum Discharge Current",
-        "device_class": "current",
-        "state_class": "number",
-        "unit": "A",
-    },
     # "work_mode": {
     #     "name": "Work Mode",
     #     "icon": "mdi:cog",
@@ -380,24 +350,6 @@ SENSOR_DEFINITIONS = {
     # Remote Control Status Sensors
     "remote_control": {
         "name": "Remote Control Status",
-    },
-    "remote_timeout_set": {
-        "name": "Remote Timeout Setting",
-        "device_class": "duration",
-        "state_class": "measurement",
-        "unit": "s",
-    },
-    "remote_active_power": {
-        "name": "Remote Active Power Command",
-        "device_class": "power",
-        "state_class": "measurement",
-        "unit": "W",
-    },
-    "remote_reactive_power": {
-        "name": "Remote Reactive Power Command",
-        "device_class": "reactive_power",
-        "state_class": "measurement",
-        "unit": "var",
     },
     "remote_timeout_countdown": {
         "name": "Remote Timeout Countdown",

--- a/custom_components/solakon_one/icons.json
+++ b/custom_components/solakon_one/icons.json
@@ -135,35 +135,11 @@
       "eps_output": {
         "default": "mdi:power-standby"
       },
-      "minimum_soc": {
-        "default": "mdi:battery-low"
-      },
-      "maximum_soc": {
-        "default": "mdi:battery-high"
-      },
-      "minimum_soc_ongrid": {
-        "default": "mdi:battery-low"
-      },
-      "battery_max_charge_current": {
-        "default": "mdi:battery-charging"
-      },
-      "battery_max_discharge_current": {
-        "default": "mdi:battery-charging"
-      },
       "network_status": {
         "default": "mdi:network"
       },
       "remote_control": {
         "default": "mdi:remote"
-      },
-      "remote_timeout_set": {
-        "default": "mdi:timer"
-      },
-      "remote_active_power": {
-        "default": "mdi:flash"
-      },
-      "remote_reactive_power": {
-        "default": "mdi:flash-outline"
       },
       "remote_timeout_countdown": {
         "default": "mdi:timer-sand"

--- a/custom_components/solakon_one/icons.json
+++ b/custom_components/solakon_one/icons.json
@@ -132,9 +132,6 @@
       "grid_frequency": {
         "default": "mdi:sine-wave"
       },
-      "eps_output": {
-        "default": "mdi:power-standby"
-      },
       "network_status": {
         "default": "mdi:network"
       },


### PR DESCRIPTION
fixes #47 

Some sensors are there as read-only sensor entities and number entities. 

This removes the plain sensors for

- minimum_soc
- maximum_soc
- minimum_soc_ongrid
- battery_max_charge_current
- battery_max_discharge_current
- remote_timeout_set
- remote_active_power
- remote_reactive_power
- eps_output

To access the values previously provided by the `sensor` entities, use the `number` platform instead.

`sensor.solakon_one_minimum_soc_ongrid` -> `number.solakon_one_minimum_soc_ongrid`
