### PR TITLE
feat: add diagnostics support

### DIFF
--- a/custom_components/solakon_one/diagnostics.py
+++ b/custom_components/solakon_one/diagnostics.py
@@ -1,0 +1,24 @@
+"""Diagnostics support for Solakon ONE."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+
+    return {
+        "entry": config_entry.as_dict(),
+        "data": coordinator.data,
+    }

--- a/custom_components/solakon_one/diagnostics.py
+++ b/custom_components/solakon_one/diagnostics.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry


### PR DESCRIPTION
This file provides diagnostics support for the Solakon ONE integration, returning configuration entry diagnostics.

https://www.home-assistant.io/integrations/diagnostics/