### PR TITLE
fix: correct typo in entity definition category key

### DIFF
--- a/custom_components/solakon_one/number.py
+++ b/custom_components/solakon_one/number.py
@@ -89,7 +89,7 @@ class SolakonNumber(SolakonEntity, NumberEntity):
         # Set entity ID
         self.entity_id = f"number.solakon_one_{number_key}"
 
-        category = definition.get("entity_category", None)
+        category = definition.get("category", None)
         if category == "diagnostic":
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
         elif category == "config":

--- a/custom_components/solakon_one/sensor.py
+++ b/custom_components/solakon_one/sensor.py
@@ -81,7 +81,7 @@ class SolakonSensor(SolakonEntity, SensorEntity):
         # Set entity ID
         self.entity_id = f"sensor.solakon_one_{sensor_key}"
         
-        category = definition.get("entity_category", None)
+        category = definition.get("category", None)
         if category == "diagnostic":
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
         elif category == "config":


### PR DESCRIPTION
This fixes a typo in the category assignment for the entities.