### PR TITLE
fix: add device_class to multiple sensor entity descriptions

### DIFF
--- a/custom_components/solakon_one/sensor.py
+++ b/custom_components/solakon_one/sensor.py
@@ -250,20 +250,22 @@ SENSOR_ENTITY_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     ),
     SensorEntityDescription(
         key="grid_standard_code",
+        device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="network_status",
+        device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="remote_control",
+        device_class=SensorDeviceClass.ENUM,
     ),
     SensorEntityDescription(
         key="remote_timeout_countdown",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DURATION,
-        entity_category=EntityCategory.CONFIG,
         native_unit_of_measurement=UnitOfTime.SECONDS,
     )
 )


### PR DESCRIPTION
Added device_class for grid_standard_code, network_status, and remote_control sensors.