### PR TITLE
refactor: use entity description key

### DIFF
--- a/custom_components/solakon_one/number.py
+++ b/custom_components/solakon_one/number.py
@@ -221,29 +221,27 @@ class SolakonNumber(SolakonEntity, NumberEntity):
         """Initialize the number entity."""
         super().__init__(coordinator, config_entry, device_info, description.key)
         self._hub = hub
-        self._number_key = description.key
         self._register_config = REGISTERS[description.key]
-
+        # Set entity description
         self.entity_description = description
-
         # Set entity ID
         self.entity_id = f"number.solakon_one_{description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if self.coordinator.data and self._number_key in self.coordinator.data:
-            value = self.coordinator.data[self._number_key]
+        if self.coordinator.data and self.entity_description.key in self.coordinator.data:
+            value = self.coordinator.data[self.entity_description.key]
 
             # Value is already processed by modbus.py (scaled and converted)
             if isinstance(value, (int, float)):
                 self._attr_native_value = float(value)
                 _LOGGER.debug(
-                    f"{self._number_key}: Read value = {self._attr_native_value}"
+                    f"{self.entity_description.key}: Read value = {self._attr_native_value}"
                 )
             else:
                 _LOGGER.warning(
-                    f"Invalid value type for {self._number_key}: {type(value)}"
+                    f"Invalid value type for {self.entity_description.key}: {type(value)}"
                 )
                 self._attr_native_value = None
         else:
@@ -268,7 +266,7 @@ class SolakonNumber(SolakonEntity, NumberEntity):
             int_value = int(value * scale)
 
         _LOGGER.info(
-            f"Setting {self._number_key} at address {address} to {value} "
+            f"Setting {self.entity_description.key} at address {address} to {value} "
             f"(raw value: {int_value}, type: {data_type}, count: {count})"
         )
 
@@ -307,14 +305,14 @@ class SolakonNumber(SolakonEntity, NumberEntity):
             success = await self._hub.async_write_registers(address, values)
 
         if success:
-            _LOGGER.info(f"Successfully set {self._number_key} to {value}")
+            _LOGGER.info(f"Successfully set {self.entity_description.key} to {value}")
             # Update the state immediately (optimistic update)
             self._attr_native_value = float(value)
             self.async_write_ha_state()
             # Request coordinator to refresh data to confirm the change
             await self.coordinator.async_request_refresh()
         else:
-            _LOGGER.error(f"Failed to set {self._number_key} to {value}")
+            _LOGGER.error(f"Failed to set {self.entity_description.key} to {value}")
 
     @property
     def available(self) -> bool:

--- a/custom_components/solakon_one/sensor.py
+++ b/custom_components/solakon_one/sensor.py
@@ -307,19 +307,16 @@ class SolakonSensor(SolakonEntity, SensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, config_entry, device_info, description.key)
-        self._sensor_key = description.key
-
+        # Set entity description
         self.entity_description = description
-
         # Set entity ID
         self.entity_id = f"sensor.solakon_one_{description.key}"
-
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if self.coordinator.data and self._sensor_key in self.coordinator.data:
-            value = self.coordinator.data[self._sensor_key]
+        if self.coordinator.data and self.entity_description.key in self.coordinator.data:
+            value = self.coordinator.data[self.entity_description.key]
 
             # Handle special cases
             if isinstance(value, dict):


### PR DESCRIPTION
This uses the `key` from the entity description throughout the entity class instead of a custom variable.