### PR TITLE
refactor(IQS): use ConfigEntry.runtime_data

### DIFF
--- a/custom_components/solakon_one/__init__.py
+++ b/custom_components/solakon_one/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from .const import PLATFORMS, SCAN_INTERVAL
 from .coordinator import SolakonDataCoordinator
 from .modbus import SolakonModbusHub
-from .types import SolakonConfigEntry
+from .types import SolakonConfigEntry, SolakonData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,8 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolakonConfigEntry) -> b
     # for coordinators that are created with a config entry.
     await coordinator.async_refresh()
 
-    entry.runtime_data.hub = hub
-    entry.runtime_data.coordinator = coordinator
+    entry.runtime_data = SolakonData(hub=hub, coordinator=coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/solakon_one/__init__.py
+++ b/custom_components/solakon_one/__init__.py
@@ -2,15 +2,13 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
-from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, PLATFORMS, SCAN_INTERVAL
+from .coordinator import SolakonDataCoordinator
 from .modbus import SolakonModbusHub
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,26 +63,3 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)
 
-
-class SolakonDataCoordinator(DataUpdateCoordinator):
-    """Class to manage fetching data from Solakon ONE."""
-
-    def __init__(self, hass: HomeAssistant, hub: SolakonModbusHub) -> None:
-        """Initialize coordinator."""
-        super().__init__(
-            hass,
-            _LOGGER,
-            name="Solakon ONE",
-            update_interval=timedelta(seconds=hub.scan_interval),
-        )
-        self.hub = hub
-
-    async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch data from Solakon ONE."""
-        try:
-            data = await self.hub.async_read_all_data()
-            if not data:
-                raise UpdateFailed("Failed to fetch data from device")
-            return data
-        except Exception as err:
-            raise UpdateFailed(f"Error communicating with device: {err}") from err

--- a/custom_components/solakon_one/binary_sensor.py
+++ b/custom_components/solakon_one/binary_sensor.py
@@ -7,13 +7,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
 from .entity import SolakonEntity
+from .types import SolakonConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,12 +28,11 @@ BINARY_SENSOR_ENTITY_DESCRIPTIONS: tuple[BinarySensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SolakonConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Solakon ONE sensor entities."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
-    hub = hass.data[DOMAIN][config_entry.entry_id]["hub"]
+    hub = config_entry.runtime_data.hub
 
     # Get device info for all binary sensors
     device_info = await hub.async_get_device_info()
@@ -43,7 +41,6 @@ async def async_setup_entry(
 
     entities.extend(
         SolakonSensor(
-            coordinator,
             config_entry,
             device_info,
             description,
@@ -59,13 +56,12 @@ class SolakonSensor(SolakonEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        coordinator,
-        config_entry: ConfigEntry,
+        config_entry: SolakonConfigEntry,
         device_info: dict,
         description: BinarySensorEntityDescription,
     ) -> None:
         """Initialize the binary sensor."""
-        super().__init__(coordinator, config_entry, device_info, description.key)
+        super().__init__(config_entry, device_info, description.key)
         # Set entity description
         self.entity_description = description
         # Set entity ID

--- a/custom_components/solakon_one/binary_sensor.py
+++ b/custom_components/solakon_one/binary_sensor.py
@@ -32,13 +32,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Solakon ONE sensor entities."""
-    hub = config_entry.runtime_data.hub
-
     # Get device info for all binary sensors
-    device_info = await hub.async_get_device_info()
+    device_info = await config_entry.runtime_data.hub.async_get_device_info()
 
     entities = []
-
     entities.extend(
         SolakonSensor(
             config_entry,
@@ -47,8 +44,8 @@ async def async_setup_entry(
         )
         for description in BINARY_SENSOR_ENTITY_DESCRIPTIONS
     )
-
-    async_add_entities(entities, True)
+    if entities:
+        async_add_entities(entities, True)
 
 
 class SolakonSensor(SolakonEntity, BinarySensorEntity):

--- a/custom_components/solakon_one/coordinator.py
+++ b/custom_components/solakon_one/coordinator.py
@@ -1,0 +1,37 @@
+"""The Solakon ONE integration."""
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .modbus import SolakonModbusHub
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SolakonDataCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching data from Solakon ONE."""
+
+    def __init__(self, hass: HomeAssistant, hub: SolakonModbusHub) -> None:
+        """Initialize coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Solakon ONE",
+            update_interval=timedelta(seconds=hub.scan_interval),
+        )
+        self.hub = hub
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data from Solakon ONE."""
+        try:
+            data = await self.hub.async_read_all_data()
+            if not data:
+                raise UpdateFailed("Failed to fetch data from device")
+            return data
+        except Exception as err:
+            raise UpdateFailed(f"Error communicating with device: {err}") from err

--- a/custom_components/solakon_one/diagnostics.py
+++ b/custom_components/solakon_one/diagnostics.py
@@ -4,18 +4,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .types import SolakonConfigEntry
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: SolakonConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
 
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    coordinator = config_entry.runtime_data.coordinator
 
     return {
         "entry": config_entry.as_dict(),

--- a/custom_components/solakon_one/entity.py
+++ b/custom_components/solakon_one/entity.py
@@ -1,11 +1,11 @@
 """Entities for the Solakon ONE integration."""
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .types import SolakonConfigEntry
 
 class SolakonEntity(CoordinatorEntity, Entity):
     """Base class for Solakon ONE entities."""
@@ -14,13 +14,12 @@ class SolakonEntity(CoordinatorEntity, Entity):
 
     def __init__(
         self,
-        coordinator,
-        config_entry: ConfigEntry,
+        config_entry: SolakonConfigEntry,
         device_info: dict,
         key: str,
     ) -> None:
         """Initialize the solakon ONE entity."""
-        super().__init__(coordinator)
+        super().__init__(config_entry.runtime_data.coordinator)
         self._config_entry = config_entry
 
         # Set unique ID

--- a/custom_components/solakon_one/number.py
+++ b/custom_components/solakon_one/number.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.number import NumberEntity, NumberMode, NumberDeviceClass, NumberEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     EntityCategory,
     PERCENTAGE,
@@ -16,8 +15,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, REGISTERS
+from .const import REGISTERS
 from .entity import SolakonEntity
+from .types import SolakonConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -160,12 +160,11 @@ FORCE_POWER_NUMBER_ENTITY_DESCRIPTION = NumberEntityDescription(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SolakonConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Solakon ONE number entities."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
-    hub = hass.data[DOMAIN][config_entry.entry_id]["hub"]
+    hub = config_entry.runtime_data.hub
 
     # Get device info
     device_info = await hub.async_get_device_info()
@@ -174,8 +173,6 @@ async def async_setup_entry(
 
     entities.extend(
         SolakonNumber(
-            coordinator,
-            hub,
             config_entry,
             device_info,
             description,
@@ -187,8 +184,6 @@ async def async_setup_entry(
     # Special handling for force_duration (virtual entity with minutes<->seconds conversion)
     entities.append(
         ForceDurationNumber(
-            coordinator,
-            hub,
             config_entry,
             device_info,
             FORCE_DURATION_NUMBER_ENTITY_DESCRIPTION,
@@ -197,8 +192,6 @@ async def async_setup_entry(
     # Special handling for force_power (writes to both 46003 and 46005)
     entities.append(
         ForcePowerNumber(
-            coordinator,
-            hub,
             config_entry,
             device_info,
             FORCE_POWER_NUMBER_ENTITY_DESCRIPTION,
@@ -214,15 +207,12 @@ class SolakonNumber(SolakonEntity, NumberEntity):
 
     def __init__(
         self,
-        coordinator,
-        hub,
-        config_entry: ConfigEntry,
+        config_entry: SolakonConfigEntry,
         device_info: dict,
         description: NumberEntityDescription,
     ) -> None:
         """Initialize the number entity."""
-        super().__init__(coordinator, config_entry, device_info, description.key)
-        self._hub = hub
+        super().__init__(config_entry, device_info, description.key)
         self._register_config = REGISTERS[description.key]
         # Set entity description
         self.entity_description = description
@@ -281,7 +271,7 @@ class SolakonNumber(SolakonEntity, NumberEntity):
             elif int_value > 0xFFFF:
                 int_value = 0xFFFF
 
-            success = await self._hub.async_write_register(address, int_value)
+            success = await self._config_entry.runtime_data.hub.async_write_register(address, int_value)
         else:
             # Multi-register write (32-bit)
             # Handle signed/unsigned conversion
@@ -304,7 +294,7 @@ class SolakonNumber(SolakonEntity, NumberEntity):
                 f"Writing 32-bit value: {int_value:#x} = [{high_word:#x}, {low_word:#x}]"
             )
 
-            success = await self._hub.async_write_registers(address, values)
+            success = await self._config_entry.runtime_data.hub.async_write_registers(address, values)
 
         if success:
             _LOGGER.info(f"Successfully set {self.entity_description.key} to {value}")
@@ -333,15 +323,12 @@ class ForceDurationNumber(SolakonEntity, NumberEntity):
 
     def __init__(
         self,
-        coordinator,
-        hub,
-        config_entry: ConfigEntry,
+        config_entry: SolakonConfigEntry,
         device_info: dict,
         description: NumberEntityDescription,
     ) -> None:
         """Initialize the force duration number entity."""
-        super().__init__(coordinator, config_entry, device_info, description.key)
-        self._hub = hub
+        super().__init__(config_entry, device_info, description.key)
 
         self.entity_description = description
 
@@ -389,7 +376,7 @@ class ForceDurationNumber(SolakonEntity, NumberEntity):
         )
 
         # Write to register 46002
-        success = await self._hub.async_write_register(address, value_seconds)
+        success = await self._config_entry.runtime_data.hub.async_write_register(address, value_seconds)
 
         if success:
             _LOGGER.info(f"Successfully set force_duration to {value} min ({value_seconds}s)")
@@ -417,15 +404,12 @@ class ForcePowerNumber(SolakonEntity, NumberEntity):
 
     def __init__(
         self,
-        coordinator,
-        hub,
-        config_entry: ConfigEntry,
+        config_entry: SolakonConfigEntry,
         device_info: dict,
         description: NumberEntityDescription,
     ) -> None:
         """Initialize the force power number entity."""
-        super().__init__(coordinator, config_entry, device_info, description.key)
-        self._hub = hub
+        super().__init__(config_entry, device_info, description.key)
 
         self.entity_description = description
 
@@ -482,8 +466,8 @@ class ForcePowerNumber(SolakonEntity, NumberEntity):
         )
 
         # Write to both registers
-        success_46003 = await self._hub.async_write_registers(address_46003, values)
-        success_46005 = await self._hub.async_write_registers(address_46005, values)
+        success_46003 = await self._config_entry.runtime_data.hub.async_write_registers(address_46003, values)
+        success_46005 = await self._config_entry.runtime_data.hub.async_write_registers(address_46005, values)
 
         if success_46003 and success_46005:
             _LOGGER.info(f"Successfully set force_power to {int_value}W")

--- a/custom_components/solakon_one/number.py
+++ b/custom_components/solakon_one/number.py
@@ -164,13 +164,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Solakon ONE number entities."""
-    hub = config_entry.runtime_data.hub
-
     # Get device info
-    device_info = await hub.async_get_device_info()
+    device_info = await config_entry.runtime_data.hub.async_get_device_info()
 
     entities = []
-
     entities.extend(
         SolakonNumber(
             config_entry,
@@ -197,7 +194,6 @@ async def async_setup_entry(
             FORCE_POWER_NUMBER_ENTITY_DESCRIPTION,
         )
     )
-
     if entities:
         async_add_entities(entities, True)
 

--- a/custom_components/solakon_one/number.py
+++ b/custom_components/solakon_one/number.py
@@ -325,9 +325,8 @@ class ForceDurationNumber(SolakonEntity, NumberEntity):
     ) -> None:
         """Initialize the force duration number entity."""
         super().__init__(config_entry, device_info, description.key)
-
+        # Set entity description
         self.entity_description = description
-
         # Set entity ID
         self.entity_id = f"number.solakon_one_{description.key}"
 
@@ -406,9 +405,8 @@ class ForcePowerNumber(SolakonEntity, NumberEntity):
     ) -> None:
         """Initialize the force power number entity."""
         super().__init__(config_entry, device_info, description.key)
-
+        # Set entity description
         self.entity_description = description
-
         # Set entity ID
         self.entity_id = f"number.solakon_one_{description.key}"
 

--- a/custom_components/solakon_one/quality_scale.yaml
+++ b/custom_components/solakon_one/quality_scale.yaml
@@ -1,0 +1,3 @@
+rules:
+  # Bronze
+  runtime-data: done

--- a/custom_components/solakon_one/select.py
+++ b/custom_components/solakon_one/select.py
@@ -116,9 +116,8 @@ class SolakonSelect(SolakonEntity, SelectEntity):
         """Initialize the select entity."""
         super().__init__(config_entry, device_info, description.key)
         self._register_config = REGISTERS[description.key]
-
+        # Set entity description
         self.entity_description = description
-
         # Set entity ID
         self.entity_id = f"select.solakon_one_{description.key}"
 
@@ -209,9 +208,8 @@ class RemoteControlModeSelect(SolakonEntity, SelectEntity):
         super().__init__(config_entry, device_info, description.key)
         self._register_key = "remote_control"
         self._register_config = REGISTERS[self._register_key]
-
+        # Set entity description
         self.entity_description = description
-
         # Set entity ID
         self.entity_id = f"select.solakon_one_{description.key}"
 
@@ -312,9 +310,8 @@ class ForceModeSelect(SolakonEntity, SelectEntity):
         super().__init__(config_entry, device_info, description.key)
         self._register_key = "remote_control"
         self._register_config = REGISTERS[self._register_key]
-
+        # Set entity description
         self.entity_description = description
-
         # Set entity ID
         self.entity_id = "select.solakon_one_{description.key}"
 

--- a/custom_components/solakon_one/select.py
+++ b/custom_components/solakon_one/select.py
@@ -120,7 +120,7 @@ class SolakonSelect(SolakonEntity, SelectEntity):
         """Initialize the select entity."""
         super().__init__(config_entry, device_info, description.key)
         self._register_config = REGISTERS[description.key]
-        
+
         self.entity_description = description
 
         # Set entity ID

--- a/custom_components/solakon_one/select.py
+++ b/custom_components/solakon_one/select.py
@@ -70,13 +70,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Solakon ONE select entities."""
-    hub = config_entry.runtime_data.hub
-
     # Get device info
-    device_info = await hub.async_get_device_info()
+    device_info = await config_entry.runtime_data.hub.async_get_device_info()
 
     entities = []
-
     entities.extend(
         SolakonSelect(
             config_entry,
@@ -103,7 +100,6 @@ async def async_setup_entry(
             FORCE_MODE_SELECT_ENTITY_DESCRIPTION,
         )
     )
-
     if entities:
         async_add_entities(entities, True)
 

--- a/custom_components/solakon_one/select.py
+++ b/custom_components/solakon_one/select.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, REGISTERS
+from .const import REGISTERS
 from .entity import SolakonEntity
 from .remote_control import mode_to_register_value, register_value_to_mode, RemoteControlMode
+from .types import SolakonConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,12 +66,11 @@ REMOTE_CONTROLL_MODE_SELECT_ENTITY_DESCRIPTION = SelectEntityDescription(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SolakonConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Solakon ONE select entities."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
-    hub = hass.data[DOMAIN][config_entry.entry_id]["hub"]
+    hub = config_entry.runtime_data.hub
 
     # Get device info
     device_info = await hub.async_get_device_info()
@@ -80,8 +79,6 @@ async def async_setup_entry(
 
     entities.extend(
         SolakonSelect(
-            coordinator,
-            hub,
             config_entry,
             device_info,
             description,
@@ -93,8 +90,6 @@ async def async_setup_entry(
     # Special handling for remote_control_mode (virtual entity)
     entities.append(
         RemoteControlModeSelect(
-            coordinator,
-            hub,
             config_entry,
             device_info,
             REMOTE_CONTROLL_MODE_SELECT_ENTITY_DESCRIPTION,
@@ -103,8 +98,6 @@ async def async_setup_entry(
     # Special handling for force_mode (virtual entity)
     entities.append(
         ForceModeSelect(
-            coordinator,
-            hub,
             config_entry,
             device_info,
             FORCE_MODE_SELECT_ENTITY_DESCRIPTION,
@@ -120,15 +113,12 @@ class SolakonSelect(SolakonEntity, SelectEntity):
 
     def __init__(
         self,
-        coordinator,
-        hub,
-        config_entry: ConfigEntry,
+        config_entry: SolakonConfigEntry,
         device_info: dict,
         description: SelectEntityDescription,
     ) -> None:
         """Initialize the select entity."""
-        super().__init__(coordinator, config_entry, device_info, description.key)
-        self._hub = hub
+        super().__init__(config_entry, device_info, description.key)
         self._register_config = REGISTERS[description.key]
         
         self.entity_description = description
@@ -187,7 +177,7 @@ class SolakonSelect(SolakonEntity, SelectEntity):
         )
 
         # Write the value to the register (single register for selects)
-        success = await self._hub.async_write_register(address, numeric_value)
+        success = await self._config_entry.runtime_data.hub.async_write_register(address, numeric_value)
 
         if success:
             _LOGGER.info(f"Successfully set {self.entity_description.key} to '{option}'")
@@ -215,15 +205,12 @@ class RemoteControlModeSelect(SolakonEntity, SelectEntity):
 
     def __init__(
         self,
-        coordinator,
-        hub,
-        config_entry: ConfigEntry,
+        config_entry: SolakonConfigEntry,
         device_info: dict,
         description: SelectEntityDescription,
     ) -> None:
         """Initialize the remote control mode select entity."""
-        super().__init__(coordinator, config_entry, device_info, description.key)
-        self._hub = hub
+        super().__init__(config_entry, device_info, description.key)
         self._register_key = "remote_control"
         self._register_config = REGISTERS[self._register_key]
 
@@ -294,7 +281,7 @@ class RemoteControlModeSelect(SolakonEntity, SelectEntity):
         )
 
         # Write the value to the register
-        success = await self._hub.async_write_register(address, register_value)
+        success = await self._config_entry.runtime_data.hub.async_write_register(address, register_value)
 
         if success:
             _LOGGER.info(f"Successfully set remote_control_mode to '{option}'")
@@ -321,15 +308,12 @@ class ForceModeSelect(SolakonEntity, SelectEntity):
 
     def __init__(
         self,
-        coordinator,
-        hub,
-        config_entry: ConfigEntry,
+        config_entry: SolakonConfigEntry,
         device_info: dict,
         description: SelectEntityDescription,
     ) -> None:
         """Initialize the force mode select entity."""
-        super().__init__(coordinator, config_entry, device_info, description.key)
-        self._hub = hub
+        super().__init__(config_entry, device_info, description.key)
         self._register_key = "remote_control"
         self._register_config = REGISTERS[self._register_key]
 
@@ -395,7 +379,7 @@ class ForceModeSelect(SolakonEntity, SelectEntity):
         )
 
         # Write the value to the register
-        success = await self._hub.async_write_register(address, mode_value)
+        success = await self._config_entry.runtime_data.hub.async_write_register(address, mode_value)
 
         if success:
             _LOGGER.info(f"Successfully set force_mode to '{option}'")

--- a/custom_components/solakon_one/sensor.py
+++ b/custom_components/solakon_one/sensor.py
@@ -9,7 +9,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     EntityCategory,
     PERCENTAGE,
@@ -25,8 +24,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
 from .entity import SolakonEntity
+from .types import SolakonConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -326,12 +325,11 @@ SENSOR_ENTITY_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: SolakonConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Solakon ONE sensor entities."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
-    hub = hass.data[DOMAIN][config_entry.entry_id]["hub"]
+    hub = config_entry.runtime_data.hub
 
     # Get device info for all sensors
     device_info = await hub.async_get_device_info()
@@ -340,7 +338,6 @@ async def async_setup_entry(
 
     entities.extend(
         SolakonSensor(
-            coordinator,
             config_entry,
             device_info,
             description,
@@ -356,13 +353,12 @@ class SolakonSensor(SolakonEntity, SensorEntity):
 
     def __init__(
         self,
-        coordinator,
-        config_entry: ConfigEntry,
+        config_entry: SolakonConfigEntry,
         device_info: dict,
         description: SensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator, config_entry, device_info, description.key)
+        super().__init__(config_entry, device_info, description.key)
         # Set entity description
         self.entity_description = description
         # Set entity ID

--- a/custom_components/solakon_one/sensor.py
+++ b/custom_components/solakon_one/sensor.py
@@ -330,13 +330,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Solakon ONE sensor entities."""
-    hub = config_entry.runtime_data.hub
-
     # Get device info for all sensors
-    device_info = await hub.async_get_device_info()
-    
-    entities = []
+    device_info = await config_entry.runtime_data.hub.async_get_device_info()
 
+    entities = []
     entities.extend(
         SolakonSensor(
             config_entry,
@@ -345,8 +342,8 @@ async def async_setup_entry(
         )
         for description in SENSOR_ENTITY_DESCRIPTIONS
     )
-
-    async_add_entities(entities, True)
+    if entities:
+        async_add_entities(entities, True)
 
 
 class SolakonSensor(SolakonEntity, SensorEntity):

--- a/custom_components/solakon_one/types.py
+++ b/custom_components/solakon_one/types.py
@@ -1,0 +1,17 @@
+"""Types for the Solakon ONE integration."""
+from dataclasses import dataclass
+
+from homeassistant.config_entries import ConfigEntry
+
+from .coordinator import SolakonDataCoordinator
+from .modbus import SolakonModbusHub
+
+@dataclass(frozen=True)
+class SolakonData:
+    """Solakon ONE data class."""
+
+    hub: SolakonModbusHub
+    coordinator: SolakonDataCoordinator
+
+
+type SolakonConfigEntry = ConfigEntry[SolakonData]

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Solakon ONE",
   "render_readme": true,
-  "homeassistant": "2024.1.0",
+  "homeassistant": "2024.4.0",
   "content_in_root": false,
   "filename": "solakon_one.zip",
   "country": ["DE"]


### PR DESCRIPTION
This is a first attempt to comply with the [*integration quality scale*](https://developers.home-assistant.io/docs/core/integration-quality-scale/).

IQS rule: https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/runtime-data/

Dev Blog Post: https://developers.home-assistant.io/blog/2024/04/30/store-runtime-data-inside-config-entry/