### PR TITLE
fix(config flow): options scan interval change

### DIFF
--- a/custom_components/solakon_one/__init__.py
+++ b/custom_components/solakon_one/__init__.py
@@ -43,16 +43,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolakonConfigEntry) -> b
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
-
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: SolakonConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hub = entry.runtime_data.hub
-        await hub.async_close()
+        await entry.runtime_data.hub.async_close()
 
     return unload_ok
 
@@ -61,4 +58,3 @@ async def async_reload_entry(hass: HomeAssistant, entry: SolakonConfigEntry) -> 
     """Reload config entry."""
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)
-

--- a/custom_components/solakon_one/__init__.py
+++ b/custom_components/solakon_one/__init__.py
@@ -22,7 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolakonConfigEntry) -> b
         entry.data[CONF_HOST],
         entry.data[CONF_PORT],
         entry.data.get(CONF_DEVICE_ID, DEFAULT_DEVICE_ID),
-        entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+        entry.options.get(CONF_SCAN_INTERVAL, entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)),
     )
 
     try:

--- a/custom_components/solakon_one/config_flow.py
+++ b/custom_components/solakon_one/config_flow.py
@@ -94,7 +94,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             errors=errors,
-            data_schema=self.add_suggested_values_to_schema(STEP_USER_DATA_SCHEMA, user_input or {}),
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA,
+                user_input or {}
+            ),
         )
 
     @staticmethod
@@ -120,21 +123,14 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
     ) -> FlowResult:
         """Manage the options."""
         if user_input is not None:
-            # Persist options
-            # self.hass.config_entries.async_update_entry(
-            #     self._config_entry, options=user_input
-            # )
-            # # Try to reload the config entry so options take effect immediately
-            # # Run as a background task so the UI isn't blocked
-            # self.hass.async_create_task(
-            #     self.hass.config_entries.async_reload(self._config_entry.entry_id)
-            # )
-            # # Finish options flow
             return self.async_create_entry(data=user_input)
 
         return self.async_show_form(
             step_id="init",
-            data_schema=self.add_suggested_values_to_schema(STEP_OPTIONS_DATA_SCHEMA, self._config_entry.options or self._config_entry.data)
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_OPTIONS_DATA_SCHEMA,
+                self._config_entry.options or self._config_entry.data
+            )
         )
 
 

--- a/custom_components/solakon_one/config_flow.py
+++ b/custom_components/solakon_one/config_flow.py
@@ -124,7 +124,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="init",
-            data_schema=self.add_suggested_values_to_schema(STEP_OPTIONS_DATA_SCHEMA, self._config_entry.data)
+            data_schema=self.add_suggested_values_to_schema(STEP_OPTIONS_DATA_SCHEMA, self._config_entry.options or self._config_entry.data)
         )
 
 

--- a/custom_components/solakon_one/config_flow.py
+++ b/custom_components/solakon_one/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.helpers import config_validation as cv
 from .const import CONF_DEVICE_ID, DEFAULT_DEVICE_ID, DEFAULT_NAME, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DOMAIN
 from .modbus import SolakonModbusHub
 
+
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
@@ -31,6 +32,13 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_OPTIONS_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=300)
+        ),
+    }
+)
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
@@ -84,7 +92,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=DEFAULT_NAME, data=user_input)
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="user",
+            errors=errors,
+            data_schema=self.add_suggested_values_to_schema(STEP_USER_DATA_SCHEMA, user_input or {}),
         )
 
     @staticmethod
@@ -114,16 +124,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL,
-                        default=self._config_entry.data.get(
-                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-                        ),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=300)),
-                }
-            ),
+            data_schema=self.add_suggested_values_to_schema(STEP_OPTIONS_DATA_SCHEMA, self._config_entry.data)
         )
 
 

--- a/custom_components/solakon_one/config_flow.py
+++ b/custom_components/solakon_one/config_flow.py
@@ -106,7 +106,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return OptionsFlowHandler(config_entry)
 
 
-class OptionsFlowHandler(config_entries.OptionsFlow):
+class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
     """Handle options flow for Solakon ONE."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
@@ -120,6 +120,16 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     ) -> FlowResult:
         """Manage the options."""
         if user_input is not None:
+            # Persist options
+            # self.hass.config_entries.async_update_entry(
+            #     self._config_entry, options=user_input
+            # )
+            # # Try to reload the config entry so options take effect immediately
+            # # Run as a background task so the UI isn't blocked
+            # self.hass.async_create_task(
+            #     self.hass.config_entries.async_reload(self._config_entry.entry_id)
+            # )
+            # # Finish options flow
             return self.async_create_entry(data=user_input)
 
         return self.async_show_form(


### PR DESCRIPTION
Changes

- keep input values if error in setup occurs
- use options scan interval first, fallback to data scan interval

fixes #33 