### PR TITLE
fix: set entity IDs automatically by HA

### DIFF
--- a/custom_components/solakon_one/binary_sensor.py
+++ b/custom_components/solakon_one/binary_sensor.py
@@ -88,8 +88,6 @@ class SolakonBinarySensor(SolakonEntity, BinarySensorEntity):
         super().__init__(config_entry, device_info, description.key)
         # Set entity description
         self.entity_description = description
-        # Set entity ID
-        self.entity_id = f"binary_sensor.solakon_one_{description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/solakon_one/number.py
+++ b/custom_components/solakon_one/number.py
@@ -220,8 +220,6 @@ class SolakonNumber(SolakonEntity, NumberEntity):
         self._register_config = REGISTERS[description.key]
         # Set entity description
         self.entity_description = description
-        # Set entity ID
-        self.entity_id = f"number.solakon_one_{description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -341,8 +339,6 @@ class ForceDurationNumber(SolakonEntity, NumberEntity):
         super().__init__(config_entry, device_info, description.key)
         # Set entity description
         self.entity_description = description
-        # Set entity ID
-        self.entity_id = f"number.solakon_one_{description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -427,8 +423,6 @@ class ForcePowerNumber(SolakonEntity, NumberEntity):
         super().__init__(config_entry, device_info, description.key)
         # Set entity description
         self.entity_description = description
-        # Set entity ID
-        self.entity_id = f"number.solakon_one_{description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/solakon_one/select.py
+++ b/custom_components/solakon_one/select.py
@@ -123,8 +123,6 @@ class SolakonSelect(SolakonEntity, SelectEntity):
         self._register_config = REGISTERS[description.key]
         # Set entity description
         self.entity_description = description
-        # Set entity ID
-        self.entity_id = f"select.solakon_one_{description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -220,8 +218,6 @@ class RemoteControlModeSelect(SolakonEntity, SelectEntity):
         self._register_config = REGISTERS[self._register_key]
         # Set entity description
         self.entity_description = description
-        # Set entity ID
-        self.entity_id = f"select.solakon_one_{description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -319,8 +315,6 @@ class ForceModeSelect(SolakonEntity, SelectEntity):
         self._register_config = REGISTERS[self._register_key]
         # Set entity description
         self.entity_description = description
-        # Set entity ID
-        self.entity_id = "select.solakon_one_{description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/solakon_one/sensor.py
+++ b/custom_components/solakon_one/sensor.py
@@ -396,8 +396,6 @@ class SolakonSensor(SolakonEntity, SensorEntity):
         super().__init__(config_entry, device_info, description.key)
         # Set entity description
         self.entity_description = description
-        # Set entity ID
-        self.entity_id = f"sensor.solakon_one_{description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
Remove the hardcoded entity IDs and let HA device on the IDs based on device name and entity key.

This supports mass regenerating the IDs by HA.

For this to take effect on existing devices, one need to remove an re-add the device.

fixes #154 
related to https://github.com/solakon-de/solakon-one-homeassistant/issues/154#issuecomment-3734541809