### PR TITLE
fix: properly merge configuration data with options

### DIFF
--- a/custom_components/solakon_one/__init__.py
+++ b/custom_components/solakon_one/__init__.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: SolakonConfigEntry) -> bool:
     """Set up Solakon ONE from a config entry."""
-    hub = get_modbus_hub(hass, entry.options | entry.data)
+    hub = get_modbus_hub(hass, entry.data | entry.options)  # let options override data
 
     try:
         await hub.async_setup()


### PR DESCRIPTION
The configuration option `scan_interval` can now override the `scan_interval` that was set during initial setup.
fixes #198 