### PR TITLE
chore: fix .gitignore to properly exclude __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 stuff/**/*
-__pycache__/**/*
+**/__pycache__/
 .DS_Store
 .env


### PR DESCRIPTION
While playing around with the code, I found that not all pycache folders are ignored.