### PR TITLE
feat: add system loss power and energy sensors (#205)

### DIFF
--- a/custom_components/solakon_one/coordinator.py
+++ b/custom_components/solakon_one/coordinator.py
@@ -33,6 +33,36 @@ class SolakonDataCoordinator(DataUpdateCoordinator):
             data = await self.hub.async_read_all_data()
             if not data:
                 raise UpdateFailed("Failed to fetch data from device")
+            self._compute_derived_values(data)
             return data
         except Exception as err:
             raise UpdateFailed(f"Error communicating with device: {err}") from err
+
+    def _compute_derived_values(self, data: dict[str, Any]) -> None:
+        """Compute derived sensor values from raw register data."""
+        # System loss power (W): PV power + battery discharge power - AC output power
+        # Note: raw battery_power is positive when charging, negative when discharging.
+        pv_power = data.get("total_pv_power")
+        battery_power_raw = data.get("battery_power")
+        ac_power = data.get("active_power")
+        if (
+            pv_power is not None
+            and battery_power_raw is not None
+            and ac_power is not None
+        ):
+            losses_w = pv_power - battery_power_raw - ac_power
+            data["system_loss_power"] = max(0, round(losses_w))
+
+        # System loss energy (kWh): (PV energy + battery discharge) - (grid export + battery charge)
+        pv_energy = data.get("pv_total_energy")
+        batt_discharge = data.get("battery_total_discharge_energy")
+        grid_export = data.get("grid_total_export_energy")
+        batt_charge = data.get("battery_total_charge_energy")
+        if (
+            pv_energy is not None
+            and batt_discharge is not None
+            and grid_export is not None
+            and batt_charge is not None
+        ):
+            losses_kwh = (pv_energy + batt_discharge) - (grid_export + batt_charge)
+            data["system_loss_energy"] = round(max(0.0, losses_kwh), 2)

--- a/custom_components/solakon_one/sensor.py
+++ b/custom_components/solakon_one/sensor.py
@@ -382,6 +382,18 @@ SENSOR_ENTITY_DESCRIPTIONS: tuple[SolakonSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         options=[0, 1, 2, 3, 4, 6, 7],
     ),
+    SolakonSensorEntityDescription(
+        key="system_loss_power",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+    ),
+    SolakonSensorEntityDescription(
+        key="system_loss_energy",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    ),
 )
 
 

--- a/custom_components/solakon_one/sensor.py
+++ b/custom_components/solakon_one/sensor.py
@@ -369,6 +369,18 @@ SENSOR_ENTITY_DESCRIPTIONS: tuple[SolakonSensorEntityDescription, ...] = (
         options=[0, 1, 2, 3, 4, 6, 7],
     ),
     SolakonSensorEntityDescription(
+        key="system_loss_power",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+    ),
+    SolakonSensorEntityDescription(
+        key="system_loss_energy",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+    ),
+    SolakonSensorEntityDescription(
         key="pv_version",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda val: f"{int(hex(val >> 8), 16)}.{int(hex(val & 0xFF), 16):03}",

--- a/custom_components/solakon_one/translations/de.json
+++ b/custom_components/solakon_one/translations/de.json
@@ -222,6 +222,12 @@
       "total_pv_power": {
         "name": "PV Leistung"
       },
+      "system_loss_power": {
+        "name": "Systemverlustleistung"
+      },
+      "system_loss_energy": {
+        "name": "Systemverlustenergie"
+      },
       "operating_mode": {
         "name": "Betriebsart",
         "state": {

--- a/custom_components/solakon_one/translations/de.json
+++ b/custom_components/solakon_one/translations/de.json
@@ -240,6 +240,12 @@
       "remote_timeout_countdown": {
         "name": "Fernsteuerung Zeitüberschreitung"
       },
+      "system_loss_energy": {
+        "name": "Systemverlustenergie"
+      },
+      "system_loss_power": {
+        "name": "Systemverlustleistung"
+      },
       "total_pv_power": {
         "name": "PV Leistung"
       }

--- a/custom_components/solakon_one/translations/en.json
+++ b/custom_components/solakon_one/translations/en.json
@@ -222,6 +222,12 @@
       "total_pv_power": {
         "name": "PV power"
       },
+      "system_loss_power": {
+        "name": "System loss power"
+      },
+      "system_loss_energy": {
+        "name": "System loss energy"
+      },
       "operating_mode": {
         "name": "Operating mode",
         "state": {

--- a/custom_components/solakon_one/translations/en.json
+++ b/custom_components/solakon_one/translations/en.json
@@ -240,6 +240,12 @@
       "remote_timeout_countdown": {
         "name": "Remote timeout countdown"
       },
+      "system_loss_energy": {
+        "name": "System loss energy"
+      },
+      "system_loss_power": {
+        "name": "System loss power"
+      },
       "total_pv_power": {
         "name": "PV power"
       }


### PR DESCRIPTION
Compute derived system loss sensors directly in the coordinator instead of requiring manual template sensors in HA:

- system_loss_power (W): max(0, pv_power - battery_power - ac_power)
- system_loss_energy (kWh): max(0, (pv_energy + batt_discharge) - (grid_export + batt_charge))

Add translations for both sensors in en/de.