### PR TITLE
feat: native Solakon PowerTracker IR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ A complete Home Assistant custom integration for Solakon ONE devices using Modbu
 
 ### Latest Version
 **New Features:**
+- ✨ **Native PowerTracker IR support**: Optional integration of the Solakon
+  PowerTracker IR via its local HTTP API. Adds `grid_power`, `grid_import_total`
+  and `grid_export_total` sensors – no more manual `rest:` YAML configuration is
+  required. Configure the meter's IP address from the integration's options.
 - ✨ **Device Control Entities**: Control your Solakon ONE device directly from Home Assistant
   - EPS Output Mode control (Disable/EPS/UPS)
   - Remote Control Mode with 9 operating modes
@@ -66,6 +70,8 @@ A complete Home Assistant custom integration for Solakon ONE devices using Modbu
 - Reactive Power
 - Load Power
 - Battery Power
+- Grid Power (W) — *requires the optional Solakon PowerTracker IR*
+- Grid Import / Export (kWh, totals) — *requires the optional Solakon PowerTracker IR*
 
 ### Voltage & Current
 - PV1/PV2/PV3/PV4 Voltage & Current
@@ -274,26 +280,35 @@ Create two integral sensors:
    - **Energy going in to the battery**: Select "Battery Charge Energy"
    - **Energy going out of the battery**: Select "Battery Discharge Energy"
 
-### Grid Import/Export (Not Currently Supported)
+### Grid Import/Export (via Solakon PowerTracker IR)
 
-Grid import and export sensors are not currently available in this integration. These values would need to be derived from the available power sensors or added in a future update if the Modbus registers support them.
+Grid power, grid import (kWh) and grid export (kWh) are provided by the optional
+Solakon PowerTracker IR. When a PowerTracker IR is configured, the integration
+polls its local API at `http://<TRACKER_IP>/api/v1/status` and exposes:
+
+- `sensor.solakon_one_grid_power` (W, `device_class: power`)
+- `sensor.solakon_one_grid_import_total` (kWh, `device_class: energy`, `state_class: total_increasing`)
+- `sensor.solakon_one_grid_export_total` (kWh, `device_class: energy`, `state_class: total_increasing`)
+
+These can be used directly in the Energy Dashboard under
+**Electricity grid → Grid consumption / Return to grid**.
 
 ### Solakon PowerTracker IR Integration
 
-You can integrate the Solakon PowerTracker IR via Home Assistant's REST sensor. Add the following to your `configuration.yaml`:
+The PowerTracker IR is integrated natively – no manual REST sensor configuration
+is required. To enable it:
 
-```yaml
-rest:
-  - resource: "http://<TRACKER_IP>/api/v1/status"
-    scan_interval: 1
-    sensor:
-      - name: "Solakon PowerTracker IR"
-        value_template: "{{ value_json.extracted.instantaneous_power_w }}"
-```
+1. Go to **Settings → Devices & Services → Solakon ONE → Configure**.
+2. Enter the IP address (or hostname) of your PowerTracker IR in the
+   **PowerTracker IR host** field.
+3. Save. The grid sensors above will appear automatically.
 
-Replace `<TRACKER_IP>` with the IP address of your PowerTracker IR.
+The same field is also available when initially adding the integration. Leave it
+empty if you don't have a PowerTracker IR.
 
-> **Note**: After adding this configuration, reload the REST integration via Developer Tools → YAML → REST. A full Home Assistant restart is not required.
+> **Migration note**: If you previously added the PowerTracker IR via a manual
+> `rest:` block in `configuration.yaml`, you can remove that block once the
+> native integration is configured.
 
 ## Automation Examples
 

--- a/custom_components/solakon_one/__init__.py
+++ b/custom_components/solakon_one/__init__.py
@@ -7,8 +7,9 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import PLATFORMS
+from .const import CONF_IR_METER_HOST, PLATFORMS
 from .coordinator import SolakonDataCoordinator
+from .ir_meter import SolakonIRMeterClient
 from .modbus import get_modbus_hub
 from .types import SolakonConfigEntry, SolakonData
 
@@ -17,7 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: SolakonConfigEntry) -> bool:
     """Set up Solakon ONE from a config entry."""
-    hub = get_modbus_hub(hass, entry.data | entry.options)  # let options override data
+    config = entry.data | entry.options  # let options override data
+    hub = get_modbus_hub(hass, config)
 
     try:
         await hub.async_setup()
@@ -27,13 +29,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolakonConfigEntry) -> b
     except Exception as err:
         raise ConfigEntryNotReady(err) from err
 
-    coordinator = SolakonDataCoordinator(hass, hub)
+    ir_meter_host = (config.get(CONF_IR_METER_HOST) or "").strip()
+    ir_meter = SolakonIRMeterClient(hass, ir_meter_host) if ir_meter_host else None
+
+    coordinator = SolakonDataCoordinator(hass, hub, ir_meter)
     # Coordinator isn't tied to a config entry object, so call a regular refresh
     # rather than async_config_entry_first_refresh which is only supported
     # for coordinators that are created with a config entry.
     await coordinator.async_refresh()
 
-    entry.runtime_data = SolakonData(hub=hub, coordinator=coordinator)
+    entry.runtime_data = SolakonData(hub=hub, coordinator=coordinator, ir_meter=ir_meter)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/solakon_one/config_flow.py
+++ b/custom_components/solakon_one/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.helpers import config_validation as cv, selector
 
 from .const import (
     CONF_DEVICE_ID,
+    CONF_IR_METER_HOST,
     DEFAULT_DEVICE_ID,
     DEFAULT_NAME,
     DEFAULT_PORT,
@@ -22,6 +23,7 @@ from .const import (
     DOMAIN,
 )
 from .exceptions import CannotConnect
+from .ir_meter import SolakonIRMeterClient
 from .modbus import get_modbus_hub
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,6 +57,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
         ): SCAN_INTERVAL_NUMBER_SELECTOR,
+        vol.Optional(CONF_IR_METER_HOST, default=""): str,
     }
 )
 
@@ -63,6 +66,7 @@ STEP_OPTIONS_DATA_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
         ): SCAN_INTERVAL_NUMBER_SELECTOR,
+        vol.Optional(CONF_IR_METER_HOST, default=""): str,
     }
 )
 
@@ -84,7 +88,17 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         await hub.async_close()
         raise CannotConnect(f"Failed to get device info: {err}") from err
 
+    ir_host = (data.get(CONF_IR_METER_HOST) or "").strip()
+    if ir_host:
+        ir_client = SolakonIRMeterClient(hass, ir_host)
+        if not await ir_client.async_test_connection():
+            raise CannotConnectIRMeter(f"Cannot reach IR meter at {ir_host}")
+
     return {"device_info": info}
+
+
+class CannotConnectIRMeter(CannotConnect):
+    """Raised when the IR meter is unreachable or returns invalid data."""
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
@@ -100,6 +114,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
         if user_input is not None:
             try:
                 await validate_input(self.hass, user_input)
+            except CannotConnectIRMeter:
+                errors[CONF_IR_METER_HOST] = "cannot_connect_ir_meter"
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:
@@ -142,13 +158,21 @@ class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options."""
+        errors: dict[str, str] = {}
         if user_input is not None:
-            return self.async_create_entry(data=user_input)
+            ir_host = (user_input.get(CONF_IR_METER_HOST) or "").strip()
+            if ir_host:
+                ir_client = SolakonIRMeterClient(self.hass, ir_host)
+                if not await ir_client.async_test_connection():
+                    errors[CONF_IR_METER_HOST] = "cannot_connect_ir_meter"
+            if not errors:
+                return self.async_create_entry(data=user_input)
 
         return self.async_show_form(
             step_id="init",
+            errors=errors,
             data_schema=self.add_suggested_values_to_schema(
                 STEP_OPTIONS_DATA_SCHEMA,
-                self._config_entry.options or self._config_entry.data,
+                user_input or self._config_entry.options or self._config_entry.data,
             ),
         )

--- a/custom_components/solakon_one/const.py
+++ b/custom_components/solakon_one/const.py
@@ -7,6 +7,7 @@ from homeassistant.const import Platform
 DOMAIN: Final = "solakon_one"
 
 CONF_DEVICE_ID: Final = "slave_id"
+CONF_IR_METER_HOST: Final = "ir_meter_host"
 
 DEFAULT_MANUFACTURER: Final = "Solakon"
 DEFAULT_MODEL: Final = "ONE"

--- a/custom_components/solakon_one/coordinator.py
+++ b/custom_components/solakon_one/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import timedelta
 from typing import Any
@@ -9,6 +10,8 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .exceptions import CannotConnect
+from .ir_meter import SolakonIRMeterClient
 from .modbus import SolakonModbusHub
 
 _LOGGER = logging.getLogger(__name__)
@@ -17,7 +20,12 @@ _LOGGER = logging.getLogger(__name__)
 class SolakonDataCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from Solakon ONE."""
 
-    def __init__(self, hass: HomeAssistant, hub: SolakonModbusHub) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        hub: SolakonModbusHub,
+        ir_meter: SolakonIRMeterClient | None = None,
+    ) -> None:
         """Initialize coordinator."""
         super().__init__(
             hass,
@@ -26,13 +34,39 @@ class SolakonDataCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=hub.scan_interval),
         )
         self.hub = hub
+        self.ir_meter = ir_meter
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from Solakon ONE."""
         try:
-            data = await self.hub.async_read_all_data()
-            if not data:
+            modbus_task = self.hub.async_read_all_data()
+            if self.ir_meter is not None:
+                ir_task = self.ir_meter.async_read_data()
+                modbus_data, ir_data = await asyncio.gather(
+                    modbus_task, ir_task, return_exceptions=True
+                )
+            else:
+                modbus_data = await modbus_task
+                ir_data = None
+
+            if isinstance(modbus_data, Exception):
+                raise UpdateFailed(
+                    f"Error communicating with device: {modbus_data}"
+                ) from modbus_data
+            if not modbus_data:
                 raise UpdateFailed("Failed to fetch data from device")
+
+            data: dict[str, Any] = dict(modbus_data)
+
+            if isinstance(ir_data, dict):
+                data.update(ir_data)
+            elif isinstance(ir_data, CannotConnect):
+                _LOGGER.debug("IR meter read failed: %s", ir_data)
+            elif isinstance(ir_data, Exception):
+                _LOGGER.warning("Unexpected IR meter error: %s", ir_data)
+
             return data
+        except UpdateFailed:
+            raise
         except Exception as err:
             raise UpdateFailed(f"Error communicating with device: {err}") from err

--- a/custom_components/solakon_one/icons.json
+++ b/custom_components/solakon_one/icons.json
@@ -73,6 +73,15 @@
       "grid_total_import_energy": {
         "default": "mdi:transmission-tower-export"
       },
+      "grid_power": {
+        "default": "mdi:transmission-tower"
+      },
+      "grid_import_total": {
+        "default": "mdi:transmission-tower-import"
+      },
+      "grid_export_total": {
+        "default": "mdi:transmission-tower-export"
+      },
       "grid_standard_code": {
         "default": "mdi:transmission-tower"
       },

--- a/custom_components/solakon_one/ir_meter.py
+++ b/custom_components/solakon_one/ir_meter.py
@@ -1,0 +1,160 @@
+"""Solakon PowerTracker IR meter HTTP client."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from aiohttp import ClientError, ClientSession, ClientTimeout
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .exceptions import CannotConnect
+
+_LOGGER = logging.getLogger(__name__)
+
+# Keys produced by this client and consumed by the coordinator/sensors.
+DATA_GRID_POWER = "grid_power"
+DATA_GRID_IMPORT_TOTAL = "grid_import_total"
+DATA_GRID_EXPORT_TOTAL = "grid_export_total"
+
+IR_METER_DATA_KEYS = (
+    DATA_GRID_POWER,
+    DATA_GRID_IMPORT_TOTAL,
+    DATA_GRID_EXPORT_TOTAL,
+)
+
+# Possible JSON paths for energy totals returned by the device. The PowerTracker
+# IR exposes the parsed SML values under the "extracted" object; the field name
+# depends on firmware/meter, so we try a few common variants.
+_IMPORT_KEYS = (
+    "total_energy_in_wh",
+    "energy_consumed_wh",
+    "total_consumed_wh",
+    "energy_in_wh",
+)
+_EXPORT_KEYS = (
+    "total_energy_out_wh",
+    "energy_delivered_wh",
+    "total_delivered_wh",
+    "energy_out_wh",
+)
+
+
+class SolakonIRMeterClient:
+    """Async client for the Solakon PowerTracker IR local API."""
+
+    def __init__(self, hass: HomeAssistant, host: str, *, timeout: float = 5.0) -> None:
+        """Initialize the IR meter client."""
+        self._hass = hass
+        self._host = host.strip()
+        self._timeout = ClientTimeout(total=timeout)
+        self._session: ClientSession = async_get_clientsession(hass)
+
+    @property
+    def host(self) -> str:
+        """Return the configured IR meter host."""
+        return self._host
+
+    @property
+    def url(self) -> str:
+        """Return the status endpoint URL."""
+        host = self._host
+        if "://" not in host:
+            host = f"http://{host}"
+        return f"{host.rstrip('/')}/api/v1/status"
+
+    async def async_test_connection(self) -> bool:
+        """Return True if the device responds with a parseable payload."""
+        try:
+            payload = await self._async_fetch()
+        except CannotConnect:
+            return False
+        return self._extract_power(payload) is not None
+
+    async def async_read_data(self) -> dict[str, Any]:
+        """Fetch and normalize data from the IR meter."""
+        payload = await self._async_fetch()
+
+        data: dict[str, Any] = {}
+
+        power = self._extract_power(payload)
+        if power is not None:
+            data[DATA_GRID_POWER] = power
+
+        import_kwh = self._extract_energy_kwh(payload, _IMPORT_KEYS)
+        if import_kwh is not None:
+            data[DATA_GRID_IMPORT_TOTAL] = import_kwh
+
+        export_kwh = self._extract_energy_kwh(payload, _EXPORT_KEYS)
+        if export_kwh is not None:
+            data[DATA_GRID_EXPORT_TOTAL] = export_kwh
+
+        return data
+
+    async def _async_fetch(self) -> dict[str, Any]:
+        """Perform the HTTP GET and return the JSON body."""
+        try:
+            async with self._session.get(self.url, timeout=self._timeout) as resp:
+                resp.raise_for_status()
+                return await resp.json(content_type=None)
+        except (ClientError, asyncio.TimeoutError, ValueError) as err:
+            raise CannotConnect(f"IR meter request failed: {err}") from err
+
+    @staticmethod
+    def _extract_power(payload: dict[str, Any]) -> float | None:
+        """Return instantaneous power in W, or None if not present."""
+        extracted = payload.get("extracted") if isinstance(payload, dict) else None
+        if isinstance(extracted, dict):
+            value = extracted.get("instantaneous_power_w")
+            if value is None:
+                value = extracted.get("power_w")
+            if value is not None:
+                return _coerce_float(value)
+
+        # Some firmwares put it at the top level.
+        if isinstance(payload, dict):
+            value = payload.get("instantaneous_power_w") or payload.get("power_w")
+            if value is not None:
+                return _coerce_float(value)
+
+        return None
+
+    @staticmethod
+    def _extract_energy_kwh(
+        payload: dict[str, Any], keys: tuple[str, ...]
+    ) -> float | None:
+        """Return cumulative energy in kWh from the first matching key."""
+        sources: list[dict[str, Any]] = []
+        if isinstance(payload, dict):
+            extracted = payload.get("extracted")
+            if isinstance(extracted, dict):
+                sources.append(extracted)
+            sources.append(payload)
+
+        for source in sources:
+            for key in keys:
+                if key in source and source[key] is not None:
+                    wh = _coerce_float(source[key])
+                    if wh is None:
+                        continue
+                    if key.endswith("_kwh"):
+                        return wh
+                    return wh / 1000.0
+
+            for key in keys:
+                kwh_key = key.replace("_wh", "_kwh")
+                if kwh_key != key and kwh_key in source and source[kwh_key] is not None:
+                    return _coerce_float(source[kwh_key])
+
+        return None
+
+
+def _coerce_float(value: Any) -> float | None:
+    """Best-effort float conversion."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/custom_components/solakon_one/sensor.py
+++ b/custom_components/solakon_one/sensor.py
@@ -29,6 +29,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import SolakonEntity
+from .ir_meter import IR_METER_DATA_KEYS
 from .types import SolakonConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -344,6 +345,26 @@ SENSOR_ENTITY_DESCRIPTIONS: tuple[SolakonSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
     ),
     SolakonSensorEntityDescription(
+        key="grid_power",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+    ),
+    SolakonSensorEntityDescription(
+        key="grid_import_total",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+    ),
+    SolakonSensorEntityDescription(
+        key="grid_export_total",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=2,
+    ),
+    SolakonSensorEntityDescription(
         key="grid_frequency",
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.FREQUENCY,
@@ -394,15 +415,17 @@ async def async_setup_entry(
     # Get device info for all sensors
     device_info = await config_entry.runtime_data.hub.async_get_device_info()
 
-    entities: list[SolakonSensor] = []
-    entities.extend(
-        SolakonSensor(
-            config_entry,
-            device_info,
-            description,
-        )
+    has_ir_meter = config_entry.runtime_data.ir_meter is not None
+    descriptions = tuple(
+        description
         for description in SENSOR_ENTITY_DESCRIPTIONS
+        if has_ir_meter or description.key not in IR_METER_DATA_KEYS
     )
+
+    entities: list[SolakonSensor] = [
+        SolakonSensor(config_entry, device_info, description)
+        for description in descriptions
+    ]
     if entities:
         async_add_entities(entities, True)
 

--- a/custom_components/solakon_one/translations/de.json
+++ b/custom_components/solakon_one/translations/de.json
@@ -8,18 +8,21 @@
           "host": "Gerät",
           "port": "Port",
           "slave_id": "Modbus Geräte ID",
-          "scan_interval": "Update Interval (Sekunden)"
+          "scan_interval": "Update Interval (Sekunden)",
+          "ir_meter_host": "PowerTracker IR (optional)"
         },
         "data_description": {
           "host": "IP Adresse des Gerätes",
           "port": "Modbus TCP Port (normalerweise 502)",
           "slave_id": "Modbus Geräte Adresse (1-247)",
-          "scan_interval": "Zeitintervall in dem Aktualisierungen am Gerät abgefragt werden sollen (1-300 Sekunden)"
+          "scan_interval": "Zeitintervall in dem Aktualisierungen am Gerät abgefragt werden sollen (1-300 Sekunden)",
+          "ir_meter_host": "IP-Adresse oder Hostname deines Solakon PowerTracker IR. Leer lassen, falls nicht vorhanden."
         }
       }
     },
     "error": {
       "cannot_connect": "Verbindung zum Gerät fehlgeschlagen",
+      "cannot_connect_ir_meter": "Verbindung zum PowerTracker IR fehlgeschlagen",
       "unknown": "Unerwarteter Fehler ist aufgetreten"
     },
     "abort": {
@@ -163,6 +166,15 @@
       "grid_total_import_energy": {
         "name": "Netz Importenergie"
       },
+      "grid_power": {
+        "name": "Netzleistung"
+      },
+      "grid_import_total": {
+        "name": "Netzbezug"
+      },
+      "grid_export_total": {
+        "name": "Netzeinspeisung"
+      },
       "grid_frequency": {
         "name": "Netzfrequenz"
       },
@@ -242,12 +254,17 @@
         "title": "Einstellungen anpassen",
         "description": "Passe die Einstellungen für dein Solakon ONE Gerät an.",
         "data": {
-          "scan_interval": "Aktualisierungsintervall (Sekunden)"
+          "scan_interval": "Aktualisierungsintervall (Sekunden)",
+          "ir_meter_host": "PowerTracker IR (optional)"
         },
         "data_description": {
-          "scan_interval": "Zeitintervall in dem Aktualisierungen am Gerät abgefragt werden sollen (1-300 Sekunden)"
+          "scan_interval": "Zeitintervall in dem Aktualisierungen am Gerät abgefragt werden sollen (1-300 Sekunden)",
+          "ir_meter_host": "IP-Adresse oder Hostname deines Solakon PowerTracker IR. Leer lassen, falls nicht vorhanden."
         }
       }
+    },
+    "error": {
+      "cannot_connect_ir_meter": "Verbindung zum PowerTracker IR fehlgeschlagen"
     }
   }
 }

--- a/custom_components/solakon_one/translations/en.json
+++ b/custom_components/solakon_one/translations/en.json
@@ -8,18 +8,21 @@
           "host": "Host",
           "port": "Port",
           "slave_id": "Modbus device ID",
-          "scan_interval": "Update interval (seconds)"
+          "scan_interval": "Update interval (seconds)",
+          "ir_meter_host": "PowerTracker IR host (optional)"
         },
         "data_description": {
           "host": "IP address of your Solakon ONE device",
           "port": "Modbus TCP port (usually 502)",
           "slave_id": "Modbus device address (1-247)",
-          "scan_interval": "Interval to poll device for updates (1-300 seconds)"
+          "scan_interval": "Interval to poll device for updates (1-300 seconds)",
+          "ir_meter_host": "IP address or hostname of your Solakon PowerTracker IR. Leave empty if you don't use one."
         }
       }
     },
     "error": {
       "cannot_connect": "Failed to connect to the device",
+      "cannot_connect_ir_meter": "Failed to reach the PowerTracker IR meter",
       "unknown": "Unexpected error occurred"
     },
     "abort": {
@@ -163,6 +166,15 @@
       "grid_total_import_energy": {
         "name": "Grid import energy"
       },
+      "grid_power": {
+        "name": "Grid power"
+      },
+      "grid_import_total": {
+        "name": "Grid import"
+      },
+      "grid_export_total": {
+        "name": "Grid export"
+      },
       "grid_frequency": {
         "name": "Grid frequency"
       },
@@ -242,12 +254,17 @@
         "title": "Configure options",
         "description": "Adjust settings for your Solakon ONE device.",
         "data": {
-          "scan_interval": "Update interval (seconds)"
+          "scan_interval": "Update interval (seconds)",
+          "ir_meter_host": "PowerTracker IR host (optional)"
         },
         "data_description": {
-          "scan_interval": "Interval to poll device for updates (1-300 seconds)"
+          "scan_interval": "Interval to poll device for updates (1-300 seconds)",
+          "ir_meter_host": "IP address or hostname of your Solakon PowerTracker IR. Leave empty if you don't use one."
         }
       }
+    },
+    "error": {
+      "cannot_connect_ir_meter": "Failed to reach the PowerTracker IR meter"
     }
   }
 }

--- a/custom_components/solakon_one/types.py
+++ b/custom_components/solakon_one/types.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from homeassistant.config_entries import ConfigEntry
 
 from .coordinator import SolakonDataCoordinator
+from .ir_meter import SolakonIRMeterClient
 from .modbus import SolakonModbusHub
 
 
@@ -14,6 +15,7 @@ class SolakonData:
 
     hub: SolakonModbusHub
     coordinator: SolakonDataCoordinator
+    ir_meter: SolakonIRMeterClient | None = None
 
 
 type SolakonConfigEntry = ConfigEntry[SolakonData]


### PR DESCRIPTION
## Summary

Closes #230.

Adds optional, native integration of the **Solakon PowerTracker IR** smart meter alongside the existing Modbus link, removing the need for the manual `rest:` YAML workaround documented in the README. When a PowerTracker IR host is configured, the integration polls its local API at `http://<host>/api/v1/status` in parallel with Modbus and exposes:

- `sensor.solakon_one_grid_power` — `W`, `device_class: power`, `state_class: measurement`
- `sensor.solakon_one_grid_import_total` — `kWh`, `device_class: energy`, `state_class: total_increasing`
- `sensor.solakon_one_grid_export_total` — `kWh`, `device_class: energy`, `state_class: total_increasing`

These map directly to the Energy Dashboard's *Electricity grid → Grid consumption / Return to grid* slots.

## Changes

- **New `ir_meter.py`** — async HTTP client using HA's shared aiohttp session; defensive JSON parser that supports the documented `extracted.instantaneous_power_w` plus several common kWh/Wh field name variants for the energy totals (firmware-dependent).
- **Config flow / options flow** — new optional `PowerTracker IR host` field, validated on save (a connection failure surfaces as a per-field error). Backwards compatible: leaving it empty preserves the previous behaviour exactly.
- **Coordinator** — Modbus and IR meter are now polled in parallel via `asyncio.gather(..., return_exceptions=True)`. A transient IR meter failure only marks the three new sensors unavailable; Modbus data continues to flow.
- **Sensors** — three new `SolakonSensorEntityDescription`s are only registered when an IR meter is configured.
- **Translations / icons** — EN + DE strings and `icons.json` updated.
- **README** — replaces the manual `rest:` block with the native setup instructions; adds a migration note and updates the feature list / Energy Dashboard guide.

## Test plan

- [ ] Add the integration with the IR host empty → no new entities, existing behaviour unchanged.
- [ ] Add the integration with a valid PowerTracker IR host → grid_power / grid_import_total / grid_export_total sensors appear and update.
- [ ] Add the integration with an unreachable IR host → config flow shows a `cannot_connect_ir_meter` error against the IR host field.
- [ ] Set the integration up, then unplug the IR meter → only the three grid sensors go unavailable; Modbus sensors keep updating.
- [ ] Reconfigure via the options flow to add / remove the IR meter host.
- [ ] Confirm `grid_import_total` / `grid_export_total` are accepted by the Energy Dashboard.
- [ ] Confirm both EN and DE labels render correctly.

## Notes

The PowerTracker IR's full JSON payload is not publicly documented. The parser tries the documented `extracted.instantaneous_power_w` plus several plausible energy field names (`total_energy_in_wh`, `energy_consumed_wh`, `total_energy_out_wh`, `energy_delivered_wh`, plus `*_kwh` variants). If a firmware uses different keys, please attach a sample `/api/v1/status` body to this PR and I'll wire the additional keys in.