### PR TITLE
feat: add reconfiguration support for connection settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ These sensors display the current values of controllable parameters:
    - **Modbus Device ID**: Usually 1 (range: 1-247)
    - **Update Interval**: How often to poll (1-300 seconds)
 
+After setup, use the integration's **Reconfigure** action to change the host or port. The existing config entry is updated, so entity IDs and recorded history are retained.
+
 ### Network Requirements
 
 - Ensure your Solakon ONE device is connected to your network

--- a/custom_components/solakon_one/config_flow.py
+++ b/custom_components/solakon_one/config_flow.py
@@ -58,6 +58,13 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_RECONFIGURE_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    }
+)
+
 STEP_OPTIONS_DATA_SCHEMA = vol.Schema(
     {
         vol.Optional(
@@ -120,6 +127,35 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
             ),
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle reconfiguration of the connection settings."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                await validate_input(self.hass, reconfigure_entry.data | user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            errors=errors,
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_RECONFIGURE_DATA_SCHEMA, reconfigure_entry.data
+            ),
+        )
+
     @staticmethod
     @callback
     def async_get_options_flow(
@@ -129,7 +165,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
         return OptionsFlowHandler(config_entry)
 
 
-class OptionsFlowHandler(config_entries.OptionsFlowWithReload):
+class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for Solakon ONE."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:

--- a/custom_components/solakon_one/translations/de.json
+++ b/custom_components/solakon_one/translations/de.json
@@ -23,6 +23,18 @@
         },
         "description": "Richte dein Solakon ONE Gerät für die Integration in Home Assistant ein.",
         "title": "Solakon ONE konfigurieren"
+      },
+      "reconfigure": {
+        "data": {
+          "host": "Gerät",
+          "port": "Port"
+        },
+        "data_description": {
+          "host": "IP-Adresse deines Solakon ONE Gerätes",
+          "port": "Modbus-TCP-Port (normalerweise 502)"
+        },
+        "description": "Aktualisiere die Verbindungseinstellungen deines Solakon ONE Gerätes.",
+        "title": "Solakon ONE neu konfigurieren"
       }
     }
   },

--- a/custom_components/solakon_one/translations/en.json
+++ b/custom_components/solakon_one/translations/en.json
@@ -23,6 +23,18 @@
         },
         "description": "Set up your Solakon ONE device for integration with Home Assistant.",
         "title": "Configure Solakon ONE"
+      },
+      "reconfigure": {
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        },
+        "data_description": {
+          "host": "IP address of your Solakon ONE device",
+          "port": "Modbus TCP port (usually 502)"
+        },
+        "description": "Update the connection settings for your Solakon ONE device.",
+        "title": "Reconfigure Solakon ONE"
       }
     }
   },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,54 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
+
+from solakon_one.config_flow import ConfigFlow
+from solakon_one.const import CONF_DEVICE_ID
+
+
+def test_reconfigure_updates_connection_without_replacing_entry_data() -> None:
+    async def run_test() -> None:
+        flow = ConfigFlow()
+        flow.hass = MagicMock()
+        entry = MagicMock()
+        entry.data = {
+            CONF_HOST: "192.0.2.10",
+            CONF_PORT: 502,
+            CONF_DEVICE_ID: 7,
+            CONF_SCAN_INTERVAL: 30,
+        }
+        user_input = {CONF_HOST: "198.51.100.20", CONF_PORT: 1502}
+
+        with (
+            patch(
+                "solakon_one.config_flow.validate_input",
+                new=AsyncMock(),
+            ) as validate_input,
+            patch.object(
+                flow,
+                "_get_reconfigure_entry",
+                return_value=entry,
+            ),
+            patch.object(
+                flow,
+                "async_update_reload_and_abort",
+                return_value={
+                    "type": "abort",
+                    "reason": "reconfigure_successful",
+                },
+            ) as update_entry,
+        ):
+            result = await flow.async_step_reconfigure(user_input)
+
+        validate_input.assert_awaited_once_with(flow.hass, entry.data | user_input)
+        update_entry.assert_called_once_with(
+            entry,
+            data_updates=user_input,
+        )
+        assert result == {
+            "type": "abort",
+            "reason": "reconfigure_successful",
+        }
+
+    asyncio.run(run_test())


### PR DESCRIPTION
This PR adds support for changing the IP address or Modbus port of an already configured Solakon ONE integration without losing its existing history.

### Previous behavior

- The IP address and port could only be configured during the initial setup.
- After a network change, the integration had to be deleted and configured again.
- This could change entity IDs and cause existing history to be lost or fragmented.

### New behavior

- The connection can be changed via **Settings → Devices & services → Solakon ONE → Reconfigure**.
- The new connection is tested before it is saved.
- If the connection test fails, the existing configuration remains unchanged.
- If successful, the existing config entry is updated and the integration is reloaded.
- Entity IDs and recorded history are preserved.
- The Modbus device ID and update interval remain unchanged.

Translations, documentation, and a regression test have also been added.